### PR TITLE
feat: add in-memory caching for GET API calls (5-min TTL)

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -39,12 +39,13 @@ vi.stubEnv('VITE_SKIP_AUTH', '');
 
 // ── Import after mocks ─────────────────────────────────────────────────────
 
-const { fetchGarments, fetchStatsSummary, fetchWearHistory, createGarment, getSasUrl, predictOutfit, confirmWear, deleteWearEvent } = await import('./api');
+const { fetchGarments, fetchStatsSummary, fetchWearHistory, createGarment, getSasUrl, predictOutfit, confirmWear, deleteWearEvent, clearApiCache } = await import('./api');
 
 // ── Setup ───────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearApiCache();
   mockGetAllAccounts.mockReturnValue([{ username: 'test@test.com' }]);
   mockAcquireTokenSilent.mockResolvedValue({ accessToken: 'mock-token-123' });
 });
@@ -200,6 +201,94 @@ describe('API Client', () => {
       mockFetch.mockResolvedValue(mockJsonResponse(404, { error: 'Not found' }));
 
       await expect(deleteWearEvent('bad-id')).rejects.toThrow();
+    });
+  });
+
+  // ── Caching behaviour ──────────────────────────────────────────────────────
+
+  describe('caching', () => {
+    it('returns cached data on second call within TTL', async () => {
+      const stats = { totalGarments: 5, totalWearEvents: 20 };
+      mockFetch.mockResolvedValue(mockJsonResponse(200, stats));
+
+      const first = await fetchStatsSummary();
+      const second = await fetchStatsSummary();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(first).toEqual(second);
+    });
+
+    it('caches fetchGarments by query params', async () => {
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { garments: [{ id: 'g1' }] }));
+
+      await fetchGarments(10);
+      await fetchGarments(10);
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('treats different query params as separate cache keys', async () => {
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { garments: [] }));
+
+      await fetchGarments(10);
+      await fetchGarments(20);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates garments + stats cache after createGarment', async () => {
+      const stats = { totalGarments: 1, totalWearEvents: 0 };
+      mockFetch.mockResolvedValue(mockJsonResponse(200, stats));
+      await fetchStatsSummary(); // populate cache
+
+      // createGarment call
+      const created = { id: 'g1', name: 'Shirt', category: 'top', wearCount: 0 };
+      mockFetch.mockResolvedValue(mockJsonResponse(201, created));
+      await createGarment('Shirt', 'top', []);
+
+      // stats cache should be invalidated — next call should hit network
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { ...stats, totalGarments: 2 }));
+      const refreshed = await fetchStatsSummary();
+      expect(refreshed.totalGarments).toBe(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3); // initial + create + re-fetch
+    });
+
+    it('invalidates stats + history cache after confirmWear', async () => {
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { events: [] }));
+      await fetchWearHistory();
+
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { id: 'we1', confirmed: true }));
+      await confirmWear('pa1', 'g1', true);
+
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { events: [{ id: 'we1' }] }));
+      const result = await fetchWearHistory();
+      expect(result.events).toHaveLength(1);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('invalidates cache after deleteWearEvent', async () => {
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { events: [{ id: 'we1' }] }));
+      await fetchWearHistory();
+
+      mockFetch.mockResolvedValue({ ok: true, status: 200, headers: new Headers() });
+      await deleteWearEvent('we1');
+
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { events: [] }));
+      const result = await fetchWearHistory();
+      expect(result.events).toHaveLength(0);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('clearApiCache forces re-fetch', async () => {
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { totalGarments: 1 }));
+      await fetchStatsSummary();
+
+      clearApiCache();
+
+      mockFetch.mockResolvedValue(mockJsonResponse(200, { totalGarments: 99 }));
+      const result = await fetchStatsSummary();
+      expect(result.totalGarments).toBe(99);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -21,6 +21,77 @@ function isAuthSkipped(): boolean {
   return import.meta.env.VITE_SKIP_AUTH === 'true';
 }
 
+// ── Response cache ────────────────────────────────────────────────────────────
+// Simple in-memory cache with TTL + in-flight request deduplication.
+// Avoids redundant GET calls when navigating between pages.
+
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+/** How long cached GET responses stay fresh (ms). */
+export const CACHE_TTL_MS = 300_000; // 5 minutes
+
+function getCached<T>(key: string): T | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.data as T;
+}
+
+function setCache<T>(key: string, data: T): void {
+  cache.set(key, { data, timestamp: Date.now() });
+}
+
+/**
+ * Fetch with caching + in-flight dedup.
+ * Returns cached data if fresh, otherwise makes the request and caches it.
+ * Concurrent calls to the same path share a single in-flight promise.
+ */
+async function cachedApiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const cached = getCached<T>(path);
+  if (cached) return cached;
+
+  const existing = inflight.get(path);
+  if (existing) return existing as Promise<T>;
+
+  const promise = apiFetch<T>(path, init)
+    .then((data) => {
+      setCache(path, data);
+      inflight.delete(path);
+      return data;
+    })
+    .catch((err) => {
+      inflight.delete(path);
+      throw err;
+    });
+
+  inflight.set(path, promise);
+  return promise;
+}
+
+/** Invalidate all cache entries whose keys start with any of the given prefixes. */
+function invalidateCache(...prefixes: string[]): void {
+  for (const key of cache.keys()) {
+    if (prefixes.some((p) => key.startsWith(p))) {
+      cache.delete(key);
+    }
+  }
+}
+
+/** Clear the entire API response cache. Useful after sign-out or for testing. */
+export function clearApiCache(): void {
+  cache.clear();
+  inflight.clear();
+}
+
 // ── Shared types ─────────────────────────────────────────────────────────────
 
 export interface GarmentSummary {
@@ -200,7 +271,7 @@ export async function fetchGarments(
   if (pageSize) params.set('pageSize', String(pageSize));
   if (continuationToken) params.set('continuationToken', continuationToken);
   const qs = params.toString();
-  return apiFetch<GarmentListResponse>(`/api/garments${qs ? `?${qs}` : ''}`);
+  return cachedApiFetch<GarmentListResponse>(`/api/garments${qs ? `?${qs}` : ''}`);
 }
 
 /**
@@ -211,11 +282,13 @@ export async function createGarment(
   category: string,
   catalogImageUrls: string[],
 ): Promise<CreatedGarment> {
-  return apiFetch<CreatedGarment>('/api/garments', {
+  const result = await apiFetch<CreatedGarment>('/api/garments', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, category, catalogImageUrls }),
   });
+  invalidateCache('/api/garments', '/api/stats');
+  return result;
 }
 
 // ── Images ───────────────────────────────────────────────────────────────────
@@ -277,11 +350,13 @@ export async function confirmWear(
   confirmedGarmentId: string,
   confirmed: boolean,
 ): Promise<WearEvent> {
-  return apiFetch<WearEvent>('/api/wear/confirm', {
+  const result = await apiFetch<WearEvent>('/api/wear/confirm', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ predictionAuditId, confirmedGarmentId, confirmed }),
   });
+  invalidateCache('/api/stats', '/api/wear/history', '/api/garments');
+  return result;
 }
 
 /**
@@ -309,6 +384,7 @@ export async function deleteWearEvent(id: string): Promise<void> {
     }
     throw new Error(message);
   }
+  invalidateCache('/api/stats', '/api/wear/history', '/api/garments');
 }
 
 // ── Stats ────────────────────────────────────────────────────────────────────
@@ -317,7 +393,7 @@ export async function deleteWearEvent(id: string): Promise<void> {
  * GET /api/stats/summary — get wear statistics for the dashboard.
  */
 export async function fetchStatsSummary(): Promise<StatsSummary> {
-  return apiFetch<StatsSummary>('/api/stats/summary');
+  return cachedApiFetch<StatsSummary>('/api/stats/summary');
 }
 
 /**
@@ -331,5 +407,5 @@ export async function fetchWearHistory(
   if (pageSize) params.set('pageSize', String(pageSize));
   if (continuationToken) params.set('continuationToken', continuationToken);
   const qs = params.toString();
-  return apiFetch<WearHistoryResponse>(`/api/wear/history${qs ? `?${qs}` : ''}`);
+  return cachedApiFetch<WearHistoryResponse>(`/api/wear/history${qs ? `?${qs}` : ''}`);
 }


### PR DESCRIPTION
## Summary

Adds lightweight in-memory caching for GET API calls to reduce redundant backend requests when navigating between pages.

### What changed

- **Cache infrastructure** in `frontend/src/api.ts`:
  - In-memory cache with **5-minute TTL**
  - **In-flight request deduplication** — concurrent calls to the same endpoint share one network request
  - **Prefix-based invalidation** — mutations automatically bust relevant cache entries

- **Cached GET endpoints**: `fetchGarments`, `fetchStatsSummary`, `fetchWearHistory`

- **Auto-invalidation after mutations**:
  | Mutation | Invalidated prefixes |
  |---|---|
  | `createGarment` | `/api/garments`, `/api/stats` |
  | `confirmWear` | `/api/stats`, `/api/wear/history`, `/api/garments` |
  | `deleteWearEvent` | `/api/stats`, `/api/wear/history`, `/api/garments` |

- **`clearApiCache()`** exported for manual use (e.g. sign-out)

- **7 new unit tests** covering cache hits, cache key isolation, invalidation after each mutation, and manual clearing

### Why 5 minutes?

- Single-user data — only the authenticated user's garments/stats are shown
- Mutations invalidate the cache immediately, so stale data isn't a concern
- Covers the typical "browse around" session without extra network calls

### Zero new dependencies